### PR TITLE
Fix: Widen illuminate/support version compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "prefer-stable": true,
     "require": {
         "php": "^8.0",
-        "illuminate/support": "^8.0|^9.0|^10.0|^11.0"
+        "illuminate/support": ">=8.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
The previous version constraint for illuminate/support was too restrictive (^8.0|^9.0|^10.0|^11.0), leading to installation issues in projects with other illuminate/support version requirements.

This change modifies the constraint to ">=8.0", allowing the package to be used with a broader range of illuminate/support versions. This addresses your reported issues where `composer require` would fail due to version conflicts.

You should test this updated package in your specific environment to ensure full compatibility.