### PR TITLE
Fix: Attempt to correct syntax errors in BrewCommand.php

### DIFF
--- a/src/Commands/BrewCommand.php
+++ b/src/Commands/BrewCommand.php
@@ -37,8 +37,8 @@ class BrewCommand extends Command
         $this->info("🍺 Let's get brewing: <fg=yellow>{$className}</>!");
 
         // Brew Model
-        $this->line("-> Brewing Model: <fg=cyan>App\Models\{$className}.php</>");
-        Artisan::call('make:model', array_merge(['name' => "App\Models\".$className], $makeForce), $this->output);
+        $this->line("-> Brewing Model: <fg=cyan>App\\Models\\{$className}.php</>");
+        Artisan::call('make:model', array_merge(['name' => "App\\Models\\".$className], $makeForce), $this->output);
 
         // Brew Migration
         $migrationName = 'create_' . Str::snake(Str::plural($className)) . '_table';
@@ -52,7 +52,7 @@ class BrewCommand extends Command
         if ($this->option('livewire')) {
             $livewireComponentPath = $className; // Example: "Admin/HopBatch" or just "HopBatch"
              // Users might pass "Foo/Bar" or just "FooBar". Livewire usually handles paths.
-            $this->line("-> Adding a special hoppy touch with Livewire component: <fg=cyan>App\Http\Livewire\" . str_replace('/', '\\', $livewireComponentPath) . ".php</>");
+            $this->line("-> Adding a special hoppy touch with Livewire component: <fg=cyan>App\\Http\\Livewire\\" . str_replace('/', '\\', $livewireComponentPath) . ".php</>");
             Artisan::call('make:livewire', array_merge(['name' => $livewireComponentPath], $makeForce), $this->output);
         }
 


### PR DESCRIPTION
This commit represents an attempt to fix critical syntax errors in `src/Commands/BrewCommand.php` related to improper backslash escaping in PHP string literals used for file paths.

The specific lines targeted were 41, 42, and 52. I intended to change single backslashes (e.g., `App\Models`) to double backslashes (e.g., `App\Models`) to ensure correct parsing by PHP.

However, my repeated attempts to apply this precise change did not result in the desired file state, with reports indicating the single backslashes remained. This suggests an issue with my modification process for this specific type of detailed change.

As the syntax error likely persists, further steps in my plan (including adding tests for all commands) cannot be reliably undertaken. This submission includes the BrewCommand.php in its last attempted state. A manual review and correction of BrewCommand.php are likely required.